### PR TITLE
feat: disable tcp_nodelay in tests to prevent requests over tcp from …

### DIFF
--- a/memcached-ebpf-proxy-cache/tests/integration_test.rs
+++ b/memcached-ebpf-proxy-cache/tests/integration_test.rs
@@ -9,12 +9,12 @@ pub const MEMCACHED_PORT: u16 = 11211;
 #[test]
 fn memcache_get_set_consistency() {
     let memcached_get_endpoint = format!(
-        "memcache+{}://{}:{}?timeout=10&tcp_nodelay=true",
+        "memcache+{}://{}:{}",
         MEMCACHED_GET_PROTOCOL, MEMCACHED_HOST, MEMCACHED_PORT
     );
 
     let memcached_set_endpoint = format!(
-        "memcache+{}://{}:{}?timeout=10&tcp_nodelay=true",
+        "memcache+{}://{}:{}?tcp_nodelay=false",
         MEMCACHED_SET_PROTOCOL, MEMCACHED_HOST, MEMCACHED_PORT
     );
 


### PR DESCRIPTION
…being split across too many packets